### PR TITLE
feat: crop two annotations together if they share the same labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ doc/.ipynb_checkpoints
 
 # emacs temporary files
 *~
+
+#jupyter notebook
+.ipynb_checkpoints


### PR DESCRIPTION
Only implemented intersection mode for now but handled exceptions.

Not sure the zip I do in [line 460](https://github.com/pyannote/pyannote-core/compare/develop...PaulLerner:feat/annotation_crop?expand=1#diff-185af82796d2a9da62b87e306b053619R460) is optimal if the tracks are different 