### PR TITLE
feat: add collar argument to timeline.Timeline.support

### DIFF
--- a/pyannote/core/annotation.py
+++ b/pyannote/core/annotation.py
@@ -1165,11 +1165,7 @@ class Annotation:
             timeline = self.label_timeline(label, copy=True)
 
             # fill the gaps shorter than collar
-            if collar > 0.:
-                gaps = timeline.gaps()
-                for gap in gaps:
-                    if gap.duration < collar:
-                        timeline.add(gap)
+            timeline = timeline.support(collar)
 
             # reconstruct annotation with merged tracks
             for segment in timeline.support():

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -94,9 +94,14 @@ def test_extent(timeline):
     assert timeline.extent() == Segment(0.5, 10)
 
 def test_support(timeline):
+    # No collar (default).
     assert list(timeline.support()) == [Segment(0.5, 4),
                                         Segment(5, 8),
                                         Segment(8.5, 10)]
+
+    # Collar of 600 ms.
+    assert list(timeline.support(.600)) == [Segment(0.5, 4),
+                                            Segment(5, 10)]
 
 def test_gaps(timeline):
     assert list(timeline.gaps()) == [Segment(4, 5),


### PR DESCRIPTION
Also refactors codebase slightly so that `annotation.Annotation.support` now
relies on the `Timeline.support` method for identifying and skipping gaps.

Useful in cases where you don't want the overhead of using `Annotation`, but would like to be able to eliminate short gaps (e.g., merging speech segments prior to training or evaluation and especially when dealing with very high segment counts).