### PR TITLE
improve: speed up from_df and from_json

### DIFF
--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,8 +1,10 @@
+import pandas as pd
 import pytest
 
 from pyannote.core import Annotation
 from pyannote.core import Segment
 from pyannote.core import Timeline
+from pyannote.core import PYANNOTE_LABEL, PYANNOTE_SEGMENT, PYANNOTE_TRACK
 
 
 @pytest.fixture
@@ -151,4 +153,32 @@ def test_support(annotation):
     expected[Segment(3, 10), 'B'] = 'Penny'
     expected[Segment(5.5, 7), 'A'] = 'Leonard'
     expected[Segment(8, 10), 'C'] = 'Sheldon'
+    assert actual == expected
+
+def test_from_records(annotation):
+    # Check that we can reconstruct an annotation from the
+    # output of itertracks.
+    records = annotation.itertracks(yield_label=True)
+    actual = Annotation.from_records(records)
+    expected = annotation
+    assert actual == expected
+
+
+def test_from_df(annotation):
+    # Check that we can reconstruct an annotation from a Pandas
+    # dataframe containing its tracks.
+    column_names = [PYANNOTE_SEGMENT, PYANNOTE_TRACK, PYANNOTE_LABEL]
+    df = pd.DataFrame.from_records(
+        annotation.itertracks(True), columns=column_names)
+    actual = Annotation.from_df(df)
+    expected = annotation
+    assert actual == expected
+
+
+def test_from_json(annotation):
+    # Check that we can reconstruct an annotation from the dict
+    # returned by for_json.
+    data = annotation.for_json()
+    actual = Annotation.from_json(data)
+    expected = annotation
     assert actual == expected


### PR DESCRIPTION
Speeds up construction of `Annotation` instances when using the `from_df` and `from_json` methods by avoiding repeated calls to `SortedSet.__setitem__`. In practice, this leads to speeds up of on the order 2X, especially when dealing with large numbers of segments. E.g.

    >>> def using_setitem(segs): 
    >>>     sdict = SortedDict() 
    >>>     for seg in segs: 
    >>>         sdict[seg] = {} 
    >>>     return sdict
    >>> def using_constructor(segs):
    >>>     return SortedDict({seg : {} for seg in segs})
    >>> segs = [Segment(n, n+1) for n in range(0, 100, 2)]
    >>> %timeit using_setitem(segs)
    135 µs ± 2.06 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
    >>> %timeit using_constructor(segs)                                                                                        
    54.6 µs ± 216 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

I have also verified this speedup using `from_df` and `from_json` on actual data (diarization and phone alignments).

A secondary benefit is the refactoring of code so that majority of the code now lives in a `from_records` method that is called by `from_df`/`from_json`.