### PR TITLE
feat: min_duration: filter out segments durations

### DIFF
--- a/pyannote/core/annotation.py
+++ b/pyannote/core/annotation.py
@@ -895,7 +895,7 @@ class Annotation:
         """
         return self.label_timeline(label, copy=False).support()
 
-    def label_duration(self, label: Label) -> float:
+    def label_duration(self, label: Label, min_duration: float = 0.0) -> float:
         """Label duration
 
         Equivalent to ``Annotation.label_timeline(label).duration()``
@@ -904,7 +904,9 @@ class Annotation:
         ----------
         label : object
             Query
-
+        min_duration: float, optional
+            Doesn't take into account segments with a duration inferior to `min_duration`
+            Defaults to take into account every segment (i.e. 0.0)
         Returns
         -------
         duration : float
@@ -917,9 +919,9 @@ class Annotation:
 
         """
 
-        return self.label_timeline(label, copy=False).duration()
+        return self.label_timeline(label, copy=False).duration(min_duration)
 
-    def chart(self, percent: bool = False) -> List[Tuple[Label, float]]:
+    def chart(self, percent: bool = False, min_duration: float = 0.0) -> List[Tuple[Label, float]]:
         """Get labels chart (from longest to shortest duration)
 
         Parameters
@@ -927,14 +929,16 @@ class Annotation:
         percent : bool, optional
             Return list of (label, percentage) tuples.
             Defaults to returning list of (label, duration) tuples.
-
+        min_duration: float, optional
+            Doesn't take into account segments with a duration inferior to `min_duration`
+            Defaults to take into account every segment (i.e. 0.0)
         Returns
         -------
         chart : list
             List of (label, duration), sorted by duration in decreasing order.
         """
 
-        chart = sorted(((L, self.label_duration(L)) for L in self.labels()),
+        chart = sorted(((L, self.label_duration(L, min_duration)) for L in self.labels()),
                        key=lambda x: x[1], reverse=True)
 
         if percent:

--- a/pyannote/core/timeline.py
+++ b/pyannote/core/timeline.py
@@ -809,11 +809,17 @@ class Timeline:
         """
         return Timeline(segments=self.support_iter(collar), uri=self.uri)
 
-    def duration(self) -> float:
+    def duration(self, min_duration: float = 0.0) -> float:
         """Timeline duration
 
         The timeline duration is the sum of the durations of the segments
         in the timeline support.
+
+        Parameters
+        ----------
+        min_duration: float, optional
+            Doesn't take into account segments with a duration inferior to `min_duration`
+            Defaults to take into account every segment (i.e. 0.0)
 
         Returns
         -------
@@ -823,7 +829,7 @@ class Timeline:
 
         # The timeline duration is the sum of the durations
         # of the segments in the timeline support.
-        return sum(s.duration for s in self.support_iter())
+        return sum(s.duration for s in self.support_iter() if s.duration > min_duration)
 
     def gaps_iter(self, support: Optional[Support] = None) -> Iterator[Segment]:
         """Like `gaps` but returns a segment generator instead


### PR DESCRIPTION
Hi,

Not sure if you're interested in this feature, I find it quite useful to get an idea of the actual annotation duration we're training a model to (when setting `min_duration` when training speaker embeddings).

I implemented it in pyannote.database.protocol.SpeakerDiarizationProtocol.stats but I'll wait on your feedback before opening another PR...