### PR TITLE
feat: resolves #57 : add support for "arrangement" option in `plot_annotation` method

### DIFF
--- a/doc/source/pyplots/annotation.py
+++ b/doc/source/pyplots/annotation.py
@@ -11,6 +11,6 @@ annotation[Segment(1, 5)] = 'Carol'
 annotation[Segment(6, 8)] = 'Bob'
 annotation[Segment(12, 18)] = 'Carol'
 annotation[Segment(7, 20)] = 'Alice'
-notebook.plot_annotation(annotation, legend=True, time=True)
+notebook.plot_annotation(annotation, legend=True, time=True, arrangement="pack")
 
 plt.show()

--- a/doc/source/pyplots/introduction.py
+++ b/doc/source/pyplots/introduction.py
@@ -12,7 +12,7 @@ annotation[Segment(1, 5)] = 'Carol'
 annotation[Segment(6, 8)] = 'Bob'
 annotation[Segment(12, 18)] = 'Carol'
 annotation[Segment(7, 20)] = 'Alice'
-notebook.plot_annotation(annotation, legend=True, time=False)
+notebook.plot_annotation(annotation, legend=True, time=False, arrangement="pack")
 
 # plot timeline
 plt.subplot(212)

--- a/pyannote/core/annotation.py
+++ b/pyannote/core/annotation.py
@@ -1430,4 +1430,4 @@ class Annotation:
             return None
 
         from .notebook import repr_annotation
-        return repr_annotation(self)
+        return repr_annotation(self, arrangement="pack")

--- a/pyannote/core/notebook.py
+++ b/pyannote/core/notebook.py
@@ -261,7 +261,7 @@ class Notebook:
             self.plot_timeline(resource, time=time)
 
         elif isinstance(resource, Annotation):
-            self.plot_annotation(resource, time=time, legend=legend)
+            self.plot_annotation(resource, time=time, legend=legend, arrangement="pack")
 
         elif isinstance(resource, SlidingWindowFeature):
             self.plot_feature(resource, time=time)
@@ -391,13 +391,13 @@ def repr_timeline(timeline: Timeline):
     return data
 
 
-def repr_annotation(annotation: Annotation):
+def repr_annotation(annotation: Annotation, arrangement="pack"):
     """Get `png` data for `annotation`"""
     import matplotlib.pyplot as plt
     figsize = plt.rcParams['figure.figsize']
     plt.rcParams['figure.figsize'] = (notebook.width, 2)
     fig, ax = plt.subplots()
-    notebook.plot_annotation(annotation, ax=ax)
+    notebook.plot_annotation(annotation, ax=ax, arrangement=arrangement)
     data = print_figure(fig, 'png')
     plt.close(fig)
     plt.rcParams['figure.figsize'] = figsize

--- a/pyannote/core/notebook.py
+++ b/pyannote/core/notebook.py
@@ -288,13 +288,27 @@ class Notebook:
 
         # ax.set_aspect(3. / self.crop.duration)
 
-    def plot_annotation(self, annotation: Annotation, ax=None, time=True, legend=True):
+    def plot_annotation(self, annotation: Annotation, ax=None, time=True, legend=True, arrangement="pack"):
+        """ plots annotation
+
+        Parameters
+        ----------
+        arrangement : str
+            To plot segments, they are grouped by certain rules, and each group is plotted
+            on a distinct line. `stack` will group segments according to their label.
+            `pack` will group segments optimally by timestamp, regardless of label.
+
+        Returns
+        -------
+
+        """
 
         if not self.crop:
             self.crop = annotation.get_timeline(copy=False).extent()
 
         cropped = annotation.crop(self.crop, mode='intersection')
         labels = cropped.labels()
+        labels_dict = {label: i for i, label in enumerate(set(labels))}
         segments = [s for s, _ in cropped.itertracks()]
 
         ax = self.setup(ax=ax, time=time)
@@ -302,6 +316,8 @@ class Notebook:
         for (segment, track, label), y in zip(
                 cropped.itertracks(yield_label=True),
                 self.get_y(segments)):
+            if arrangement == "stack":
+                y = 1.0 - 1.0 / (len(labels) + 1) * (1 + labels_dict.get(label))
             self.draw_segment(ax, segment, y, label=label)
 
         if legend:

--- a/pyannote/core/notebook.py
+++ b/pyannote/core/notebook.py
@@ -308,17 +308,22 @@ class Notebook:
 
         cropped = annotation.crop(self.crop, mode='intersection')
         labels = cropped.labels()
-        labels_dict = {label: i for i, label in enumerate(set(labels))}
         segments = [s for s, _ in cropped.itertracks()]
 
         ax = self.setup(ax=ax, time=time)
 
-        for (segment, track, label), y in zip(
-                cropped.itertracks(yield_label=True),
-                self.get_y(segments)):
-            if arrangement == "stack":
+        if arrangement == "pack":
+            for (segment, track, label), y in zip(
+                    cropped.itertracks(yield_label=True),
+                    self.get_y(segments)):
+                self.draw_segment(ax, segment, y, label=label)
+
+        elif arrangement == "stack":
+            labels_dict = {label: i for i, label in enumerate(set(labels))}
+            for (segment, track, label) in \
+                    cropped.itertracks(yield_label=True):
                 y = 1.0 - 1.0 / (len(labels) + 1) * (1 + labels_dict.get(label))
-            self.draw_segment(ax, segment, y, label=label)
+                self.draw_segment(ax, segment, y, label=label)
 
         if legend:
             H, L = ax.get_legend_handles_labels()


### PR DESCRIPTION
```python
def plot_annotation(..., arrangement="pack"):
    ...
```
When `arrangement` is:

- `pack`:  follows default grouping, by timestamps only
- `stack`:  groups segments by their label. Each label gets a distinct line


