### PR TITLE
Please consider `SEGMENT_PRECISION` for `order, equal`

### DIFF
--- a/pyannote/core/__init__.py
+++ b/pyannote/core/__init__.py
@@ -39,7 +39,7 @@ PYANNOTE_LABEL = 'label'
 PYANNOTE_SCORE = 'score'
 PYANNOTE_IDENTITY = 'identity'
 
-from .segment import Segment, SlidingWindow
+from .segment import Segment, SlidingWindow, set_precision
 from .timeline import Timeline
 from .annotation import Annotation
 from .feature import SlidingWindowFeature
@@ -48,3 +48,6 @@ try:
     from .notebook import notebook
 except ImportError as e:
     pass
+
+set_precision()
+

--- a/pyannote/core/__init__.py
+++ b/pyannote/core/__init__.py
@@ -39,7 +39,7 @@ PYANNOTE_LABEL = 'label'
 PYANNOTE_SCORE = 'score'
 PYANNOTE_IDENTITY = 'identity'
 
-from .segment import Segment, SlidingWindow, set_precision
+from .segment import Segment, SlidingWindow
 from .timeline import Timeline
 from .annotation import Annotation
 from .feature import SlidingWindowFeature
@@ -49,5 +49,5 @@ try:
 except ImportError as e:
     pass
 
-set_precision()
+Segment.set_precision()
 

--- a/pyannote/core/segment.py
+++ b/pyannote/core/segment.py
@@ -64,7 +64,8 @@ It is nothing more than 2-tuples augmented with several useful methods and prope
   In [11]: segment.overlaps(3)  # does segment overlap time t=3?
 
 
-Use `Segment.set_precision(ndigits)` to automatically round start and end timestamps to `ndigits` precision after the decimal point. 
+Use `Segment.set_precision(ndigits)` to automatically round start and end timestamps to `ndigits` precision after the decimal point.
+To ensure consistency between `Segment` instances, it is recommended to call this method only once, right after importing `pyannote.core.Segment`.
 
 .. code-block:: ipython
 
@@ -130,8 +131,12 @@ class Segment:
     def set_precision(ndigits: Optional[int] = None):
         """Automatically round start and end timestamps to `ndigits` precision after the decimal point
 
+        To ensure consistency between `Segment` instances, it is recommended to call this method only 
+        once, right after importing `pyannote.core.Segment`.
+
         Usage
         -----
+        >>> from pyannote.core import Segment
         >>> Segment.set_precision(2)
         >>> Segment(1/3, 2/3)
         <Segment(0.33, 0.67)>

--- a/pyannote/core/segment.py
+++ b/pyannote/core/segment.py
@@ -74,8 +74,20 @@ from .utils.types import Alignment
 import numpy as np
 from dataclasses import dataclass
 
-# 1 μs (one microsecond)
-SEGMENT_PRECISION = 1e-6
+
+def set_precision(ndigits: Optional[int] = None):
+    global FORCE_ROUND_TIME
+    global SEGMENT_PRECISION
+
+    if ndigits is None:
+        # backward compatibility
+        FORCE_ROUND_TIME = False
+        # 1 μs (one microsecond)
+        SEGMENT_PRECISION = 1e-6
+    else:
+        FORCE_ROUND_TIME = True
+        SEGMENT_PRECISION = 10 ** (-ndigits)
+
 
 # setting 'frozen' to True makes it hashable and immutable
 @dataclass(frozen=True, order=True)
@@ -131,8 +143,9 @@ class Segment:
         return bool((self.end - self.start) > SEGMENT_PRECISION)
 
     def __post_init__(self):
-        object.__setattr__(self, 'start', int(self.start / SEGMENT_PRECISION + 0.5) * SEGMENT_PRECISION)
-        object.__setattr__(self, 'end', int(self.end / SEGMENT_PRECISION + 0.5) * SEGMENT_PRECISION)
+        if FORCE_ROUND_TIME:
+            object.__setattr__(self, 'start', int(self.start / SEGMENT_PRECISION + 0.5) * SEGMENT_PRECISION)
+            object.__setattr__(self, 'end', int(self.end / SEGMENT_PRECISION + 0.5) * SEGMENT_PRECISION)
 
     @property
     def duration(self) -> float:

--- a/pyannote/core/segment.py
+++ b/pyannote/core/segment.py
@@ -130,6 +130,10 @@ class Segment:
         """
         return bool((self.end - self.start) > SEGMENT_PRECISION)
 
+    def __post_init__(self):
+        object.__setattr__(self, 'start', int(self.start / SEGMENT_PRECISION + 0.5) * SEGMENT_PRECISION)
+        object.__setattr__(self, 'end', int(self.end / SEGMENT_PRECISION + 0.5) * SEGMENT_PRECISION)
+
     @property
     def duration(self) -> float:
         """Segment duration (read-only)"""

--- a/pyannote/core/segment.py
+++ b/pyannote/core/segment.py
@@ -3,7 +3,7 @@
 
 # The MIT License (MIT)
 
-# Copyright (c) 2014-2019 CNRS
+# Copyright (c) 2014-2021 CNRS
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -64,19 +64,17 @@ It is nothing more than 2-tuples augmented with several useful methods and prope
   In [11]: segment.overlaps(3)  # does segment overlap time t=3?
 
 
-When you handle float value with Segment, you can set precision digits. It will force round up to `ndigits`
+Use `Segment.set_precision(ndigits)` to automatically round start and end timestamps to `ndigits` precision after the decimal point. 
 
 .. code-block:: ipython
 
-  In [12]: from pyannote.core import set_precision
+  In [12]: Segment(1/1000, 330/1000) == Segment(1/1000, 90/1000+240/1000)
+  Out[12]: False
 
-  In [13]: Segment(1/1000, 330/1000) == Segment(1/1000, 90/1000+240/1000)
-  Out[13]: False
+  In [13]: Segment.set_precision(ndigits=4)
 
-  In [14]: set_precision(4)
-
-  In [15]: Segment(1/1000, 330/1000) == Segment(1/1000, 90/1000+240/1000)
-  Out[15]: True
+  In [14]: Segment(1/1000, 330/1000) == Segment(1/1000, 90/1000+240/1000)
+  Out[14]: True
 
 See :class:`pyannote.core.Segment` for the complete reference.
 """
@@ -130,22 +128,24 @@ class Segment:
 
     @staticmethod
     def set_precision(ndigits: Optional[int] = None):
-        """Care SEGMENT_PRECISION
+        """Automatically round start and end timestamps to `ndigits` precision after the decimal point
 
+        Usage
+        -----
         >>> Segment.set_precision(2)
         >>> Segment(1/3, 2/3)
-            <Segment(0.33, 0.67)>
+        <Segment(0.33, 0.67)>
         """
-        global FORCE_ROUND_TIME
+        global AUTO_ROUND_TIME
         global SEGMENT_PRECISION
 
         if ndigits is None:
             # backward compatibility
-            FORCE_ROUND_TIME = False
+            AUTO_ROUND_TIME = False
             # 1 μs (one microsecond)
             SEGMENT_PRECISION = 1e-6
         else:
-            FORCE_ROUND_TIME = True
+            AUTO_ROUND_TIME = True
             SEGMENT_PRECISION = 10 ** (-ndigits)
 
     def __bool__(self):
@@ -164,8 +164,8 @@ class Segment:
         return bool((self.end - self.start) > SEGMENT_PRECISION)
 
     def __post_init__(self):
-        """Round start and end with SEGMENT_PRECISION"""
-        if FORCE_ROUND_TIME:
+        """Round start and end up to SEGMENT_PRECISION precision (when required)"""
+        if AUTO_ROUND_TIME:
             object.__setattr__(self, 'start', int(self.start / SEGMENT_PRECISION + 0.5) * SEGMENT_PRECISION)
             object.__setattr__(self, 'end', int(self.end / SEGMENT_PRECISION + 0.5) * SEGMENT_PRECISION)
 

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -1,4 +1,4 @@
-from pyannote.core import Segment, set_precision
+from pyannote.core import Segment
 
 
 def test_creation():
@@ -48,5 +48,5 @@ def test_other_operation():
 
 def test_segment_precision_mode():
     assert not Segment(90/1000, 90/1000+240/1000) == Segment(90/1000, 330/1000)
-    set_precision(4)
+    Segment.set_precision(4)
     assert Segment(90/1000, 90/1000+240/1000) == Segment(90/1000, 330/1000)

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -1,4 +1,5 @@
-from pyannote.core import Segment
+from pyannote.core import Segment, set_precision
+
 
 def test_creation():
 
@@ -43,3 +44,9 @@ def test_other_operation():
 
     other_segment = Segment(14, 15)
     assert segment ^ other_segment == Segment(9, 14)
+
+
+def test_segment_precision_mode():
+    assert not Segment(90/1000, 90/1000+240/1000) == Segment(90/1000, 330/1000)
+    set_precision(4)
+    assert Segment(90/1000, 90/1000+240/1000) == Segment(90/1000, 330/1000)


### PR DESCRIPTION
Originally, Segment cannot consider  SEGMENT_PRECISION in ordering or comparing Segments like below.

```
from pyannote.core import Segment
print(Segment(1.0000005,2.00000006)  == Segment(1.0000005,2.00))
# False
```

This PR fix Segment with `__post_init__` to consider SEGMENT_PRECISION with start and end.

Would you please consider any other way to compare Segment's (start, end) with another Segments's (start, end) with SEGMENT_PRECISION?

For example, I wish below equality test would be `True`
```
print(Segment(90/1000, 90/1000+240/1000) == Segment(90/1000, 330/1000))
# Expected: True
# Actual: False
```

ref: https://docs.python.org/3/library/dataclasses.html#frozen-instances