### PR TITLE
[bug] break when empty Timeline

### DIFF
--- a/pyannote/core/segment.py
+++ b/pyannote/core/segment.py
@@ -170,7 +170,7 @@ class Segment:
 
     def __post_init__(self):
         """Round start and end up to SEGMENT_PRECISION precision (when required)"""
-        if AUTO_ROUND_TIME:
+        if self and AUTO_ROUND_TIME:
             object.__setattr__(self, 'start', int(self.start / SEGMENT_PRECISION + 0.5) * SEGMENT_PRECISION)
             object.__setattr__(self, 'end', int(self.end / SEGMENT_PRECISION + 0.5) * SEGMENT_PRECISION)
 

--- a/pyannote/core/segment.py
+++ b/pyannote/core/segment.py
@@ -170,7 +170,7 @@ class Segment:
 
     def __post_init__(self):
         """Round start and end up to SEGMENT_PRECISION precision (when required)"""
-        if self and AUTO_ROUND_TIME:
+        if AUTO_ROUND_TIME and self:
             object.__setattr__(self, 'start', int(self.start / SEGMENT_PRECISION + 0.5) * SEGMENT_PRECISION)
             object.__setattr__(self, 'end', int(self.end / SEGMENT_PRECISION + 0.5) * SEGMENT_PRECISION)
 

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -118,6 +118,13 @@ def test_gaps(timeline):
                                      Segment(8, 8.5)]
 
 
+def test_empty_gaps():
+    empty_timeline = Timeline(uri='MyAudioFile')
+    assert list(empty_timeline.gaps()) == []
+    Segment.set_precision(3)
+    assert list(empty_timeline.gaps()) == []
+
+
 def test_crop(timeline):
     selection = Segment(3, 7)
 


### PR DESCRIPTION
I figured out before `__post_init__`, checking emptiness is useful.