### PR TITLE
fix: discretize annotation with the same number of frames consistently for the same support duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,7 @@ doc/.ipynb_checkpoints
 # emacs temporary files
 *~
 
+# PyCharm
+.idea/
+
 .mypy_cache/

--- a/pyannote/core/annotation.py
+++ b/pyannote/core/annotation.py
@@ -1375,10 +1375,10 @@ class Annotation:
 
     def discretize(
         self,
-        support: Segment = None,
+        support: Optional[Segment] = None,
         resolution: Union[float, SlidingWindow] = 0.01,
-        labels: List[Hashable] = None,
-        fixed: bool = False,
+        labels: Optional[List[Hashable]] = None,
+        duration: Optional[float] = None,
     ):
         """Discretize
         
@@ -1391,8 +1391,10 @@ class Annotation:
             Defaults to 10ms frames.
         labels : list of labels, optional
             Defaults to self.labels()
-        fixed : bool, optional
-            Whether to fix the number of frames by support duration
+        duration : float, optional
+            Overrides support duration and ensures that the number of
+            returned frames is fixed (which might otherwise not be the case
+            because of rounding errors).
 
         Returns
         -------
@@ -1419,11 +1421,11 @@ class Annotation:
             )
 
         start_frame = resolution.closest_frame(start_time)
-        if fixed:
-            num_frames = int(round(support.duration / resolution.step))
-        else:
+        if duration is None:
             end_frame = resolution.closest_frame(end_time)
             num_frames = end_frame - start_frame
+        else:
+            num_frames = int(round(duration / resolution.step))
 
         data = np.zeros((num_frames, len(labels)), dtype=np.uint8)
         for k, label in enumerate(labels):

--- a/pyannote/core/annotation.py
+++ b/pyannote/core/annotation.py
@@ -1376,8 +1376,9 @@ class Annotation:
     def discretize(
         self,
         support: Segment = None,
-        resolution: Union[float, SlidingWindow] = 0.1,
+        resolution: Union[float, SlidingWindow] = 0.01,
         labels: List[Hashable] = None,
+        fixed: bool = False,
     ):
         """Discretize
         
@@ -1390,6 +1391,8 @@ class Annotation:
             Defaults to 10ms frames.
         labels : list of labels, optional
             Defaults to self.labels()
+        fixed : bool, optional
+            Whether to fix the number of frames by support duration
 
         Returns
         -------
@@ -1416,8 +1419,11 @@ class Annotation:
             )
 
         start_frame = resolution.closest_frame(start_time)
-        end_frame = resolution.closest_frame(end_time)
-        num_frames = end_frame - start_frame
+        if fixed:
+            num_frames = int(round(support.duration / resolution.step))
+        else:
+            end_frame = resolution.closest_frame(end_time)
+            num_frames = end_frame - start_frame
 
         data = np.zeros((num_frames, len(labels)), dtype=np.uint8)
         for k, label in enumerate(labels):


### PR DESCRIPTION
## Changelog

- Add `fixed` argument in `Annotation.discretize()`
- Fix incorrect default value for `resolution` (was 100ms instead of 10ms)
- Improve `Annotation.discretize()` argument types (add optionals)
- Add PyCharm `.idea` directory to `.gitignore` for contributors using PyCharm

## Problem

Because of rounding errors or banking's rounding in `numpy.rint()` (see [this thread](https://stackoverflow.com/questions/28617841/rounding-to-nearest-int-with-numpy-rint-not-consistent-for-5)), `Segment.closest_frame()` may return boundary frames that don't correspond to the support duration in `Annotation.discretize()`.

This is a problem because two supports of the same duration might be discretized to a different number of frames, which makes it unpredictable and difficult to work with:

```python
duration = 5
num_frames = 293
resolution = duration / num_frames
# let's say `annotation` has 2 speakers in both intervals
annotation.discretize(Segment(0, 5), resolution=resolution).data.shape
# output: (292, 2) -- but the correct number of frames is 293
annotation.discretize(Segment(1, 6), resolution=resolution).data.shape
# output: (293, 2)
```

## Proposition

Add a `fixed: bool = False` argument to `Annotation.discretize()` to fix the number of frames to the duration of the support according to the resolution:

```python
# let's say `annotation` has 2 speakers in both intervals
annotation.discretize(Segment(0, 5), resolution=resolution).data.shape
# output: (292, 2)
annotation.discretize(Segment(0, 5), resolution=resolution, fixed=True).data.shape
# output: (293, 2)
```
