### PR TITLE
Make Annotation.write_rttm follow most of RTTM specs

### DIFF
--- a/pyannote/core/annotation.py
+++ b/pyannote/core/annotation.py
@@ -391,10 +391,16 @@ class Annotation:
                     f'containing spaces (got: "{label}").'
                 )
                 raise ValueError(msg)
-            line = (
-                f"SPEAKER {uri} 1 {segment.start:.3f} {segment.duration:.3f} "
-                f"<NA> <NA> {label} <NA> <NA>\n"
-            )
+            if label not in ['noise', 'music', 'other']:
+                line = (
+                    f"SPEAKER {uri} 1 {segment.start:.3f} {segment.duration:.3f} "
+                    f"<NA> <NA> {label} <NA> <NA>\n"
+                )
+            else:
+                line = (
+                    f"NON-SPEECH {uri} 1 {segment.start:.3f} {segment.duration:.3f} "
+                    f"<NA> <NA> {label} <NA> <NA>\n"
+                )
             file.write(line)
 
     def crop(self, support: Support, mode: CropMode = "intersection") -> "Annotation":


### PR DESCRIPTION
The method `write_rttm()` only allow the type **SPEAKER** in the first field of the RTTM File. 

This pull request is for adding the type **NON-SPEECH** in field 1, if the label of the segment it's one of the 3 subtypes allowed in the RTTM File Format Specification (noise, music or other).