### PR TITLE
Get an RTTM string from an Annotation object

### DIFF
--- a/pyannote/core/annotation.py
+++ b/pyannote/core/annotation.py
@@ -364,19 +364,7 @@ class Annotation:
         """
         return included in self.get_timeline(copy=False)
 
-    def write_rttm(self, file: TextIO):
-        """Dump annotation to file using RTTM format
-
-        Parameters
-        ----------
-        file : file object
-
-        Usage
-        -----
-        >>> with open('file.rttm', 'w') as file:
-        ...     annotation.write_rttm(file)
-        """
-
+    def _iter_rttm(self):
         uri = self.uri if self.uri else "<NA>"
         if isinstance(uri, Text) and " " in uri:
             msg = (
@@ -391,10 +379,34 @@ class Annotation:
                     f'containing spaces (got: "{label}").'
                 )
                 raise ValueError(msg)
-            line = (
+            yield (
                 f"SPEAKER {uri} 1 {segment.start:.3f} {segment.duration:.3f} "
                 f"<NA> <NA> {label} <NA> <NA>\n"
             )
+
+    def to_rttm(self) -> Text:
+        """Serialize annotation as a string using RTTM format
+
+        Returns
+        -------
+        serialized: str
+            RTTM string
+        """
+        return "".join([line for line in self._iter_rttm()])
+
+    def write_rttm(self, file: TextIO):
+        """Dump annotation to file using RTTM format
+
+        Parameters
+        ----------
+        file : file object
+
+        Usage
+        -----
+        >>> with open('file.rttm', 'w') as file:
+        ...     annotation.write_rttm(file)
+        """
+        for line in self._iter_rttm():
             file.write(line)
 
     def write_lab(self, file: TextIO):

--- a/pyannote/core/timeline.py
+++ b/pyannote/core/timeline.py
@@ -1069,6 +1069,32 @@ class Timeline:
 
         return annotation
 
+    def _iter_uem(self) -> Iterator[Text]:
+        """Generate lines for a UEM file for this timeline
+
+        Returns
+        -------
+        iterator: Iterator[str]
+            An iterator over UEM text lines
+        """
+        uri = self.uri if self.uri else "<NA>"
+        if isinstance(uri, Text) and ' ' in uri:
+            msg = (f'Space-separated UEM file format does not allow file URIs '
+                   f'containing spaces (got: "{uri}").')
+            raise ValueError(msg)
+        for segment in self:
+            yield f"{uri} 1 {segment.start:.3f} {segment.end:.3f}\n"
+
+    def to_uem(self) -> Text:
+        """Serialize timeline as a string using UEM format
+
+        Returns
+        -------
+        serialized: str
+            UEM string
+        """
+        return "".join([line for line in self._iter_uem()])
+
     def write_uem(self, file: TextIO):
         """Dump timeline to file using UEM format
 
@@ -1081,14 +1107,7 @@ class Timeline:
         >>> with open('file.uem', 'w') as file:
         ...    timeline.write_uem(file)
         """
-
-        uri = self.uri if self.uri else "<NA>"
-        if isinstance(uri, Text) and ' ' in uri:
-            msg = (f'Space-separated UEM file format does not allow file URIs '
-                   f'containing spaces (got: "{uri}").')
-            raise ValueError(msg)
-        for segment in self:
-            line = f"{uri} 1 {segment.start:.3f} {segment.end:.3f}\n"
+        for line in self._iter_uem():
             file.write(line)
 
     def for_json(self):


### PR DESCRIPTION
## Problem

Sometimes it's useful to obtain an RTTM string without writing to a file. For example in real-time applications one may want to send pieces of `Annotation` through the network.

## Solution

I added the method `to_rttm()` in `Annotation` to do exactly this. Some refactoring was needed to avoid duplicate code between `write_rttm()` and `to_rttm()`.

## Example

```python
model = SomeDiarizationSystem()
for audio_chunk in microphone:
    annotation = model(audio_chunk)
    some_socket.send(annotation.to_rttm())
```