### PR TITLE
remove MatplotlibDeprecationWarning

### DIFF
--- a/pyannote/core/notebook.py
+++ b/pyannote/core/notebook.py
@@ -126,7 +126,7 @@ class Notebook:
         self.reset()
 
     def reset(self):
-        from matplotlib.cm import get_cmap
+        from matplotlib.pyplot import get_cmap
 
         linewidth = [3, 1]
         linestyle = ["solid", "dashed", "dotted"]


### PR DESCRIPTION
```
MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
  get_cmap("Set1")
```

matplotlib will remove `from matplotlib.cm import get_cmap`