### PR TITLE
feat: Add audacity marker file support and creating annotation from rttm file

### DIFF
--- a/pyannote/core/annotation.py
+++ b/pyannote/core/annotation.py
@@ -187,15 +187,17 @@ class Annotation:
         """
         segment_list = []
         for line in rttm_file:
-            splitted_line = line.rstrip().split(" ")
-            uri = uri if isinstance(uri,str) else splitted_line[1]
-            segment_list.append(
-                (
-                    Segment(start=float(splitted_line[3]), end=float(splitted_line[3]) + float(splitted_line[4])),
-                    int(splitted_line[2]),
-                    str(splitted_line[7]),
+            if not line.isspace() :
+                line =  ' '.join(line.split()) # Remove eventual multiple and trailing spaces in rttm line
+                splitted_line = line.rstrip().split(" ") 
+                uri = uri if isinstance(uri,str) else splitted_line[1]
+                segment_list.append(
+                    (
+                        Segment(start=float(splitted_line[3]), end=float(splitted_line[3]) + float(splitted_line[4])),
+                        int(splitted_line[2]),
+                        str(splitted_line[7]),
+                    )
                 )
-            )
         return Annotation.from_records(segment_list, uri, modality)
 
     @classmethod
@@ -224,10 +226,11 @@ class Annotation:
         """
         segment_list = []
         for line in audacity_file:
-            start, end, label = line.rstrip().split("\t")
-            segment_list.append(
-                (Segment(start=float(start), end=float(end)), 1, str(label))
-            )
+            if not line.isspace() :
+                start, end, label = line.rstrip().split("\t")
+                segment_list.append(
+                    (Segment(start=float(start), end=float(end)), 1, str(label))
+                )
         return Annotation.from_records(segment_list, uri, modality)
 
     @classmethod

--- a/pyannote/core/annotation.py
+++ b/pyannote/core/annotation.py
@@ -162,6 +162,75 @@ class Annotation:
     """
 
     @classmethod
+    def from_rttm(
+        cls, 
+        rttm_file: TextIO, 
+        uri: Optional[str] = None, 
+        modality: Optional[str] = None,
+    ) -> "Annotation":
+        """Create annotation from rttm
+
+        Parameters
+        ----------
+        rttm_file : string,
+            path to the rttm file
+        uri : string, optional
+            name of annotated resource (e.g. audio or video file)
+        modality : string, optional
+            name of annotated modality
+
+        Returns
+        -------
+        annotation : Annotation
+            New annotation
+
+        """
+        segment_list = []
+        for line in rttm_file:
+            splitted_line = line.rstrip().split(" ")
+            uri = uri if isinstance(uri,str) else splitted_line[1]
+            segment_list.append(
+                (
+                    Segment(start=float(splitted_line[3]), end=float(splitted_line[3]) + float(splitted_line[4])),
+                    int(splitted_line[2]),
+                    str(splitted_line[7]),
+                )
+            )
+        return Annotation.from_records(segment_list, uri, modality)
+
+    @classmethod
+    def from_audacity(
+        cls,
+        audacity_file: str,
+        uri: Optional[str] = None,
+        modality: Optional[str] = None,
+    ) -> "Annotation":
+        """Create annotation from audacity marker file
+
+        Parameters
+        ----------
+        audacity_txt_file : string,
+            path to the rttm file
+        uri : string, optional
+            name of annotated resource (e.g. audio or video file)
+        modality : string, optional
+            name of annotated modality
+
+        Returns
+        -------
+        annotation : Annotation
+            New annotation
+
+        """
+        segment_list = []
+        for line in audacity_file:
+            start, end, label = line.rstrip().split("\t")
+            segment_list.append(
+                (Segment(start=float(start), end=float(end)), 1, str(label))
+            )
+        return Annotation.from_records(segment_list, uri, modality)
+
+    @classmethod
     def from_df(
         cls,
         df: "pd.DataFrame",

--- a/pyannote/core/annotation.py
+++ b/pyannote/core/annotation.py
@@ -407,6 +407,17 @@ class Annotation:
                 raise ValueError(msg)
             yield f"{segment.start:.3f} {segment.start + segment.duration:.3f} {label}\n"
 
+    def _iter_audacity(self) -> Iterator[Text]:
+        """Generate lines for a audacity marker file for this annotation
+
+        Returns
+        -------
+        iterator: Iterator[str]
+            An iterator over audacity text lines
+        """
+        for segment, _, label in self.itertracks(yield_label=True):
+            yield f"{segment.start:.3f}\t{segment.start + segment.duration:.3f}\t{label}\n"
+
     def _serialize(self, iter_func : Callable) -> Text :
         """Serialize annotation as a string given an iter function
 


### PR DESCRIPTION
## Problem
When evaluating speaker diarization pipelines, one might want to use Annotation objects and creating annotation from rttm (or other format) as well as serializing/writing annotation to rttm (or other format).
Audacity marker track feature is  a very convenient (and free) way to create ground truth segmentation for speaker diarization. The format is a .txt file very similar to already implemented LAB file support but tab separated.

## Solution
### Refactor methods for various file format support

- Create a generic `_serialize` method to replace multiple `to_{format}` methods.
- Create a generic `_write` method method to replace multiple `write_{format}` methods.
- `to_<format>` and `write_<format>` are now partial methods from generic methods.

Currently supported formats are : 
 - Rttm : `annotation.to_rttm()` and `annotation.write_rttm(file)`.
 - Audacity :  `annotation.to_audacity()` and `annotation.write_audacity(file)`.
 - Lab  :  `annotation.to_lab()` and `annotation.write_lab(file)`.

Therefore, to add a new format one only need to implement `_iter_{format}` methods similarly to `_iter_rttm` or `_iter_lab`.

### Creating annotation from audacity or rttm
Similarly to the `from_df` class methods, I created `from_audacity` and `from_rttm` class methods to create easily annotations from those file formats.

Usage : 
``` Python
with open('file.rttm') as f : 
      annotation = Annotation.from_rttm(f)
```