### PR TITLE
Fix return type of Timeline.__iter__

### DIFF
--- a/pyannote/core/timeline.py
+++ b/pyannote/core/timeline.py
@@ -182,7 +182,7 @@ class Timeline:
         """
         return len(self.segments_set_) > 0
 
-    def __iter__(self) -> Iterable[Segment]:
+    def __iter__(self) -> Iterator[Segment]:
         """Iterate over segments (in chronological order)
 
         >>> for segment in timeline:


### PR DESCRIPTION
Small fix of provided typing. `Timeline.__iter__` already returns iterator (not just iterable) as required -- This change propagates this information to the actual annotation.