### PR TITLE
Typing of core classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 MANIFEST
 .Python
 env/
+venv/
 bin/
 build/
 develop-eggs/

--- a/pyannote/core/feature.py
+++ b/pyannote/core/feature.py
@@ -36,11 +36,11 @@ See :class:`pyannote.core.SlidingWindowFeature` for the complete reference.
 """
 import numbers
 import warnings
-from typing import Tuple, Optional, Union, Iterator, List, Text
+from typing import Tuple, Optional, Union, Iterator, List
 
 import numpy as np
 
-from pyannote.core.utils.types import Alignment
+from pyannote.core.utils.types import Alignment, Label
 from .segment import Segment
 from .segment import SlidingWindow
 from .timeline import Timeline
@@ -58,7 +58,7 @@ class SlidingWindowFeature(np.lib.mixins.NDArrayOperatorsMixin):
     """
 
     def __init__(
-        self, data: np.ndarray, sliding_window: SlidingWindow, labels: List[Text] = None
+        self, data: np.ndarray, sliding_window: SlidingWindow, labels: Optional[List[Label]] = None
     ):
         self.sliding_window: SlidingWindow = sliding_window
         self.data = data
@@ -106,7 +106,7 @@ class SlidingWindowFeature(np.lib.mixins.NDArrayOperatorsMixin):
         self.__i += 1
         try:
             return self.sliding_window[self.__i], self.data[self.__i]
-        except IndexError as e:
+        except IndexError:
             raise StopIteration()
 
     def next(self):

--- a/pyannote/core/utils/types.py
+++ b/pyannote/core/utils/types.py
@@ -1,6 +1,13 @@
-from typing import Hashable, Union, Tuple, Iterator
+from typing import Hashable, Union, Tuple, Iterator, TYPE_CHECKING
 
 from typing_extensions import Literal
+
+if TYPE_CHECKING:
+    from pyannote.core.segment import Segment
+    from pyannote.core.timeline import Timeline
+    from pyannote.core.feature import SlidingWindowFeature
+    from pyannote.core.annotation import Annotation
+
 
 Label = Hashable
 Support = Union['Segment', 'Timeline']


### PR DESCRIPTION
This PR should make working with `Annotation` easier for those using type checkers.

In my own project I neede to wrap `Annotation` with another class and add ugly type-checked code like this:
```python
class Diarization:
... 
    @classmethod
    def labeled_tracks(cls, diarization: Annotation) -> List[Tuple[Segment, TrackName, Label]]:
       return list(diarization.itertracks(yield_label=True))  # type: ignore
```

Now typed versions of `yield_label=True` and `yield_label=False` exist. Type checkers do not allow to "set the type" by parameter value.

## Details
- fix type erros in pyannote.core.feature.py
- fix type erros in pyannote.core.utils.types.py
- Add named tuples `SegmentTrack` and `SegmentTrackLabel` as return types for itertracks in annotation.py


### Notes on NamedTuples

`SegmentTrack(NamedTuple)` and `SegmentTrackLabel(NamedTuple)` are fully compatible with Tuple[Segment, TrackName]` and `Tuple[Segment, TrackName, Label]`, i.e. they can be deconstructed via `a,b,c = ...` and accessed with `tup[0]`, `tup[1]`
In addition the fields can be accessed via dot-notation. This also works type-checked for the union type of `SegmentTrack` and `SegmentTrackLabel` for the common fields.


```
class SegmentTrack(NamedTuple):
    segment: Segment
    track: TrackName

class SegmentTrackLabel(NamedTuple):
    segment: Segment
    track: TrackName
    label: Label

s1 = SegmentTrack(...)
s2 = SegmentTrackLabel(...)

segment, track = s1 # OK!
segment, track, label = s2 # OK!

some_s: Union[SegmentTrack, SegmentTrackLabel] = s1 # or s2
print(some_s.segment) # OK!
print(some_s.track) # OK!

``` 