### PR TITLE
fix(SlidingWindowFeature): fix PNG render with one feature

### DIFF
--- a/pyannote/core/notebook.py
+++ b/pyannote/core/notebook.py
@@ -442,7 +442,8 @@ def repr_feature(feature: SlidingWindowFeature):
 
         plt.rcParams["figure.figsize"] = (notebook.width, 1.5 * num_overlap)
 
-        fig, axes = plt.subplots(nrows=num_overlap, ncols=1,)
+        fig, axes = plt.subplots(nrows=num_overlap, ncols=1, squeeze=False)
+        axes = axes.flatten()
         mini, maxi = np.nanmin(feature.data), np.nanmax(feature.data)
         ylim = (mini - 0.2 * (maxi - mini), maxi + 0.2 * (maxi - mini))
         for c, (window, data) in enumerate(feature):

--- a/pyannote/core/notebook.py
+++ b/pyannote/core/notebook.py
@@ -341,7 +341,7 @@ class Notebook:
     ):
 
         if not self.crop:
-            self.crop = feature.getExtent()
+            self.crop = feature.extent
 
         window = feature.sliding_window
         n, dimension = feature.data.shape

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -12,6 +12,13 @@ def features():
     return SlidingWindowFeature(data, window)
 
 @pytest.fixture
+def one_feature():
+    return SlidingWindowFeature(
+        np.array([ [[0, 0, 0]], [[1, 1, 1]] ]),
+        SlidingWindow()
+    )
+
+@pytest.fixture
 def segment():
     return Segment(3.3, 6.7)
 
@@ -47,3 +54,23 @@ def test_crop_fixed_out_of_bounds(features):
     expected = np.array([[0, 0, 0, 0, 1, 2, 3, 4, 5],
                          [10, 10, 10, 10, 11, 12, 13, 14, 15]]).T
     np.testing.assert_array_equal(expected, actual)
+
+def test_repr_png(features):
+    try:
+        import matplotlib
+        import IPython
+    except ModuleNotFoundError:
+        pytest.skip("notebook dependencies not available")
+    expected = b'\x89PNG'
+    actual = features._repr_png_()[:4]
+    assert expected == actual
+
+def test_repr_png_one_feature(one_feature):
+    try:
+        import matplotlib
+        import IPython
+    except ModuleNotFoundError:
+        pytest.skip("notebook dependencies not available")
+    expected = b'\x89PNG'
+    actual = one_feature._repr_png_()[:4]
+    assert expected == actual


### PR DESCRIPTION
`plt.subplots()` when called without explicitly setting the `squeeze` argument to False will try to squeeze out extra dimensions from the returned `axes` ndarray. Currently the code relies on this behaviour to get a 1-dimensional array when we pass in a hardcoded value of 1 for `ncols`, but does not count on this squeezing out *all* dimensions and returning a single `Axes` object when the (non-hardcoded) `nrows` is also 1.

To fix this we set the `squeeze` argument to False and manually call `.flatten()` on the returned ndarray, to ensure we always get an exactly 1D array of Axes out.