### PR TITLE
fix: fix type hint of Timeline.to_annotation

### DIFF
--- a/pyannote/core/timeline.py
+++ b/pyannote/core/timeline.py
@@ -1034,7 +1034,7 @@ class Timeline:
         return Timeline(segments=segments, uri=self.uri)
 
     def to_annotation(self,
-                      generator: Union[str, Iterable[Label], None, None] = 'string',
+                      generator: Union[str, Iterable[Label]] = 'string',
                       modality: Optional[str] = None) \
             -> 'Annotation':
         """Turn timeline into an annotation


### PR DESCRIPTION
If `generator` is set to `None`, the function would raise an Exception in line 1067 when `next(generator)` is call on `None`.  So I guess generator should never be `None`.

At first I only wanted to correct the duplicate `None` in the type hint, so I would update the type hint, if `None` is handled in any other way.